### PR TITLE
Use render_parent to render new issue template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'render_parent', '~> 0'

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,42 +1,14 @@
-<h2><%=l(:label_issue_new)%></h2>
-
-<%= call_hook(:view_issues_new_top, {:issue => @issue}) %>
-
-<%= labelled_form_for @issue, :url => project_issues_path(@project),
-                             :html => {:id => 'issue-form', :multipart => true} do |f| %>
-  <%= error_messages_for 'issue' %>
-  <%= hidden_field_tag 'copy_from', params[:copy_from] if params[:copy_from] %>
-  <div class="box tabular">
-    <div id="all_attributes">
-    <%= render :partial => 'issues/form', :locals => {:f => f} %>
-    </div>
-
-    <% if @copy_from && @copy_from.attachments.any? %>
-    <p>
-      <label for="copy_attachments"><%= l(:label_copy_attachments) %></label>
-      <%= check_box_tag 'copy_attachments', '1', @copy_attachments %>
-    </p>
-    <% end %>
-
-    <p id="attachments_form"><%= label_tag('attachments[1][file]', l(:label_attachment_plural))%><%= render :partial => 'attachments/form', :locals => {:container => @issue} %></p>
-
-    <% if @issue.safe_attribute? 'watcher_user_ids' -%>
-      <%# VVK start %>
-      <%= render :partial => 'boards_watchers/watchers_list', :locals => { :watched_obj => @issue, :watched_param_name => 'issue[watcher_user_ids][]'} %>
-      <%# VVK end %>
-    <% end %>
-  </div>
-
-  <%= submit_tag l(:button_create) %>
-  <%= submit_tag l(:button_create_and_continue), :name => 'continue' %>
-
-<%= preview_link preview_new_issue_path(:project_id => @project), 'issue-form' %>
-  <%= javascript_tag "$('#issue_subject').focus();" %>
-<% end %>
-
-<div id="preview" class="wiki"></div>
-
-<% content_for :header_tags do %>
-    <%= stylesheet_link_tag 'scm' %>
-    <%= robot_exclusion_tag %>
-<% end %>
+<% html = Nokogiri::HTML.fragment(render(:parent, params: params)) %>
+<% html.at_css('p#watchers_form').replace(
+    render partial: 'boards_watchers/watchers_list', locals: {
+      watched_obj:        @issue,
+      watched_param_name: 'issue[watcher_user_ids][]',
+      watched_project:    @project || @issue.project
+    }
+   ) %>
+<%#
+  Remove the script tag which contains a seemingly unnecessary code, which break thing when used with Nokogiri output.
+  The removal doesn't seem to break anything.
+%>
+<% html.at_css('div#all_attributes > script:last-child').remove %>
+<%= raw html %>


### PR DESCRIPTION
Before this commit the plugin used copy-paste method to provide modified
templates. The new issue template was just a copy of a original redmine
template with a few strings modified.

This led to some problems. First of all, the plugin failed in some cases
with some newer versions of redmine. For instance, with redmine 3.3.8
it happened to respond `500` result when the "New issue" page was access
outside of a project scope. This can be tested by clicking at the
"New issue" link at `http://redmine-host-name/issues` path.

In order to solve this problem I used a different approach of modifying
the original view templates. This approach is described at the redmine
boards [1]. The approach implies usage of the `'render_parent'` gem which
allows you to render an original view when you override it by a plugin.
The original view render is then modified with a help of Nokogiri. Thus
I created a new new issue view template which loads the original
template and replaces the original watcher form with a new one. It also
remove a JS script snippet from the original page which seem unnecessary
and break things when is used with Nokogiri.

[1] https://www.redmine.org/boards/3/topics/33949